### PR TITLE
Update .gitignore to ignore new files after build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 .shipit
 inc/
 *.tar.gz
+*.swp
+META.yml
+MYMETA.json
+MYMETA.yml
+Makefile
+Makefile.old
+pm_to_blib
+blib/*


### PR DESCRIPTION
Some files generated by running make were not in the .gitignore file,
this adds them all in there.
It also adds vim swp files.